### PR TITLE
[Tool] add send media message images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,18 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 RUN apt-get update && \
     apt-get install -y wget gnupg && \
     apt-get install -y fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-        libgtk2.0-0 libnss3 libatk-bridge2.0-0 libdrm2 libxkbcommon0 libgbm1 libasound2 && \
+    libgtk2.0-0 libnss3 libatk-bridge2.0-0 libdrm2 libxkbcommon0 libgbm1 libasound2 && \
     apt-get install -y chromium && \
     apt-get clean
 
 WORKDIR /project
 
-COPY package.json /project/package.json
+# Copy all necessary files first
+COPY package*.json tsconfig.json ./
+COPY src/ ./src/
+
+# Then install and build
 RUN npm install
-COPY tsconfig.json /project/tsconfig.json
-COPY src/ /project/src
 RUN npm run build
 
 ENV DOCKER_CONTAINER=true

--- a/README.md
+++ b/README.md
@@ -175,20 +175,21 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api 
 
 ### Available Tools
 
-| Tool                          | Description                                             | Parameters                                                                                        |
-| ----------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `get_status`                  | Check WhatsApp client connection status                 | None                                                                                              |
-| `send_message`                | Send messages to WhatsApp contacts                      | `number`: Phone number to send to<br>`message`: Text content to send                              |
-| `search_contacts`             | Search for contacts by name or number                   | `query`: Search term to find contacts                                                             |
-| `get_messages`                | Retrieve messages from a specific chat                  | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve |
-| `get_chats`                   | Get a list of all WhatsApp chats                        | None                                                                                              |
-| `create_group`                | Create a new WhatsApp group                             | `name`: Name of the group<br>`participants`: Array of phone numbers to add                        |
-| `add_participants_to_group`   | Add participants to an existing group                   | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add                       |
-| `get_group_messages`          | Retrieve messages from a group                          | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve                  |
-| `send_group_message`          | Send a message to a group                               | `groupId`: ID of the group<br>`message`: Text content to send                                     |
-| `search_groups`               | Search for groups by name, description, or member names | `query`: Search term to find groups                                                               |
-| `get_group_by_id`             | Get detailed information about a specific group         | `groupId`: ID of the group to get                                                                 |
-| `download_media_from_message` | Download media from a message                           | `messageId`: ID of the message containing media to download                                       |
+| Tool                          | Description                                             | Parameters                                                                                                                                                                |
+| ----------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_status`                  | Check WhatsApp client connection status                 | None                                                                                                                                                                      |
+| `send_message`                | Send messages to WhatsApp contacts                      | `number`: Phone number to send to<br>`message`: Text content to send                                                                                                      |
+| `search_contacts`             | Search for contacts by name or number                   | `query`: Search term to find contacts                                                                                                                                     |
+| `get_messages`                | Retrieve messages from a specific chat                  | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve                                                                         |
+| `get_chats`                   | Get a list of all WhatsApp chats                        | None                                                                                                                                                                      |
+| `create_group`                | Create a new WhatsApp group                             | `name`: Name of the group<br>`participants`: Array of phone numbers to add                                                                                                |
+| `add_participants_to_group`   | Add participants to an existing group                   | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add                                                                                               |
+| `get_group_messages`          | Retrieve messages from a group                          | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve                                                                                          |
+| `send_group_message`          | Send a message to a group                               | `groupId`: ID of the group<br>`message`: Text content to send                                                                                                             |
+| `search_groups`               | Search for groups by name, description, or member names | `query`: Search term to find groups                                                                                                                                       |
+| `get_group_by_id`             | Get detailed information about a specific group         | `groupId`: ID of the group to get                                                                                                                                         |
+| `download_media_from_message` | Download media from a message                           | `messageId`: ID of the message containing media to download                                                                                                               |
+| `send_media_message`          | Send a media message to a WhatsApp contact              | `number`: Phone number to send to<br>`mediaType`: Source type (`url` or `local`)<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption for the media |
 
 ### Available Resources
 
@@ -205,15 +206,16 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api 
 
 #### Contacts & Messages
 
-| Endpoint                                   | Method | Description                    | Parameters                                        |
-| ------------------------------------------ | ------ | ------------------------------ | ------------------------------------------------- |
-| `/api/status`                              | GET    | Get WhatsApp connection status | None                                              |
-| `/api/contacts`                            | GET    | Get all contacts               | None                                              |
-| `/api/contacts/search`                     | GET    | Search for contacts            | `query`: Search term                              |
-| `/api/chats`                               | GET    | Get all chats                  | None                                              |
-| `/api/messages/{number}`                   | GET    | Get messages from a chat       | `limit` (query): Number of messages               |
-| `/api/send`                                | POST   | Send a message                 | `number`: Recipient<br>`message`: Message content |
-| `/api/messages/{messageId}/media/download` | POST   | Download media from a message  | None                                              |
+| Endpoint                                   | Method | Description                    | Parameters                                                                                                                      |
+| ------------------------------------------ | ------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/status`                              | GET    | Get WhatsApp connection status | None                                                                                                                            |
+| `/api/contacts`                            | GET    | Get all contacts               | None                                                                                                                            |
+| `/api/contacts/search`                     | GET    | Search for contacts            | `query`: Search term                                                                                                            |
+| `/api/chats`                               | GET    | Get all chats                  | None                                                                                                                            |
+| `/api/messages/{number}`                   | GET    | Get messages from a chat       | `limit` (query): Number of messages                                                                                             |
+| `/api/send`                                | POST   | Send a message                 | `number`: Recipient<br>`message`: Message content                                                                               |
+| `/api/send/media`                          | POST   | Send a media message           | `number`: Recipient<br>`mediaType`: `url` or `local`<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption |
+| `/api/messages/{messageId}/media/download` | POST   | Download media from a message  | None                                                                                                                            |
 
 #### Group Management
 
@@ -431,10 +433,11 @@ This workflow requires an NPM_TOKEN secret to be configured in your GitHub repos
 - Group chat management
 - Contact management and search
 - Message history retrieval
+- Sending media messages (images only)
 
 ## Upcoming Features
 
-- Support for sending media files (images, audio, documents)
+- Support for sending all media file types (video, audio, documents)
 - Enhanced message templates for common scenarios
 - Advanced group management features
 - Contact management (add/remove contacts)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 | `search_groups` | Search for groups by name, description, or member names | `query`: Search term to find groups |
 | `get_group_by_id` | Get detailed information about a specific group | `groupId`: ID of the group to get |
 | `download_media_from_message` | Download media from a message | `messageId`: ID of the message containing media to download |
-| `send_media_message` | Send a media message to a WhatsApp contact | `number`: Phone number to send to<br>`mediaType`: Source type (`url` or `local`)<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption for the media |
+| `send_media_message` | Send a media message to a WhatsApp contact | `number`: Phone number to send to<br>`source`: Media source with URI scheme (use `http://` or `https://` for URLs, `file://` for local files)<br>`caption` (optional): Text caption for the media |
 
 ### Available Resources
 
@@ -215,7 +215,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 | `/api/chats` | GET | Get all chats | None |
 | `/api/messages/{number}` | GET | Get messages from a chat | `limit` (query): Number of messages |
 | `/api/send` | POST | Send a message | `number`: Recipient<br>`message`: Message content |
-| `/api/send/media` | POST | Send a media message | `number`: Recipient<br>`mediaType`: `url` or `local`<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption |
+| `/api/send/media` | POST | Send a media message | `number`: Recipient<br>`source`: Media source with URI scheme (use `http://` or `https://` for URLs, `file://` for local files)<br>`caption` (optional): Text caption |
 | `/api/messages/{messageId}/media/download` | POST | Download media from a message | None |
 
 #### Group Management

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To learn more about using WhatsApp Web MCP in real-world scenarios, check out th
 | `--mode`           | `-m`  | Run mode                                              | `mcp`, `whatsapp-api` | `mcp`                       |
 | `--mcp-mode`       | `-c`  | MCP connection mode                                   | `standalone`, `api`   | `standalone`                |
 | `--transport`      | `-t`  | MCP transport mode                                    | `sse`, `command`      | `sse`                       |
-| `--sse-port`       | `-p`  | Port for SSE server                                   | -                     | `7002`                      |
+| `--sse-port`       | `-p`  | Port for SSE server                                   | -                     | `3002`                      |
 | `--api-port`       | -     | Port for WhatsApp API server                          | -                     | `3001`                      |
 | `--auth-data-path` | `-a`  | Path to store authentication data                     | -                     | `.wwebjs_auth`              |
 | `--auth-strategy`  | `-s`  | Authentication strategy                               | `local`, `none`       | `local`                     |
@@ -158,7 +158,7 @@ npx wweb-mcp --mode whatsapp-api --api-port 3001
 Run an MCP server that directly connects to WhatsApp Web:
 
 ```bash
-npx wweb-mcp --mode mcp --mcp-mode standalone --transport sse --sse-port 7002
+npx wweb-mcp --mode mcp --mcp-mode standalone --transport sse --sse-port 3002
 ```
 
 #### MCP Server (API Client)
@@ -170,7 +170,7 @@ Run an MCP server that connects to the WhatsApp API server:
 npx wweb-mcp --mode whatsapp-api --api-port 3001
 
 # Then, start the MCP server with the API key
-npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api --api-key YOUR_API_KEY --transport sse --sse-port 7002
+npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api --api-key YOUR_API_KEY --transport sse --sse-port 3002
 ```
 
 ### Available Tools

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ To learn more about using WhatsApp Web MCP in real-world scenarios, check out th
 | `--mcp-mode`       | `-c`  | MCP connection mode                                   | `standalone`, `api`   | `standalone`                |
 | `--transport`      | `-t`  | MCP transport mode                                    | `sse`, `command`      | `sse`                       |
 | `--sse-port`       | `-p`  | Port for SSE server                                   | -                     | `7002`                      |
-| `--api-port`       | -     | Port for WhatsApp API server                          | -                     | `7001`                      |
+| `--api-port`       | -     | Port for WhatsApp API server                          | -                     | `3001`                      |
 | `--auth-data-path` | `-a`  | Path to store authentication data                     | -                     | `.wwebjs_auth`              |
 | `--auth-strategy`  | `-s`  | Authentication strategy                               | `local`, `none`       | `local`                     |
-| `--api-base-url`   | `-b`  | API base URL for MCP when using api mode              | -                     | `http://localhost:7001/api` |
+| `--api-base-url`   | `-b`  | API base URL for MCP when using api mode              | -                     | `http://localhost:3001/api` |
 | `--api-key`        | `-k`  | API key for WhatsApp Web REST API when using api mode | -                     | `''`                        |
 
 ### API Key Authentication
@@ -79,7 +79,7 @@ WhatsApp API key: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd
 To connect the MCP server to the WhatsApp API server, you need to provide this API key using the `--api-key` or `-k` option:
 
 ```bash
-npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api --api-key 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api --api-key 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 ```
 
 The API key is stored in the authentication data directory (specified by `--auth-data-path`) and persists between restarts of the WhatsApp API server.
@@ -150,7 +150,7 @@ When a message is received and passes the filters, a POST request will be sent t
 Run a standalone WhatsApp API server that exposes WhatsApp functionality through REST endpoints:
 
 ```bash
-npx wweb-mcp --mode whatsapp-api --api-port 7001
+npx wweb-mcp --mode whatsapp-api --api-port 3001
 ```
 
 #### MCP Server (Standalone)
@@ -167,10 +167,10 @@ Run an MCP server that connects to the WhatsApp API server:
 
 ```bash
 # First, start the WhatsApp API server and note the API key from the logs
-npx wweb-mcp --mode whatsapp-api --api-port 7001
+npx wweb-mcp --mode whatsapp-api --api-port 3001
 
 # Then, start the MCP server with the API key
-npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api --api-key YOUR_API_KEY --transport sse --sse-port 7002
+npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api --api-key YOUR_API_KEY --transport sse --sse-port 7002
 ```
 
 ### Available Tools
@@ -266,7 +266,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api 
            "-t",
            "command",
            "--api-base-url",
-           "http://localhost:7001/api",
+           "http://localhost:3001/api",
            "--api-key",
            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
          ]
@@ -280,7 +280,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api 
 1. Start WhatsApp API server in Docker:
 
    ```bash
-   docker run -i -p 7001:7001 -v wweb-mcp:/wwebjs_auth --rm wweb-mcp:latest -m whatsapp-api -s local -a /wwebjs_auth
+   docker run -i -p 3001:3001 -v wweb-mcp:/wwebjs_auth --rm wweb-mcp:latest -m whatsapp-api -s local -a /wwebjs_auth
    ```
 
 2. Scan the QR code with your WhatsApp mobile app
@@ -312,7 +312,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api 
            "-t",
            "command",
            "--api-base-url",
-           "http://host.docker.internal:7001/api",
+           "http://host.docker.internal:3001/api",
            "--api-key",
            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
          ]

--- a/README.md
+++ b/README.md
@@ -175,21 +175,20 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 
 ### Available Tools
 
-| Tool                          | Description                                             | Parameters                                                                                                                                                                |
-| ----------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `get_status`                  | Check WhatsApp client connection status                 | None                                                                                                                                                                      |
-| `send_message`                | Send messages to WhatsApp contacts                      | `number`: Phone number to send to<br>`message`: Text content to send                                                                                                      |
-| `search_contacts`             | Search for contacts by name or number                   | `query`: Search term to find contacts                                                                                                                                     |
-| `get_messages`                | Retrieve messages from a specific chat                  | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve                                                                         |
-| `get_chats`                   | Get a list of all WhatsApp chats                        | None                                                                                                                                                                      |
-| `create_group`                | Create a new WhatsApp group                             | `name`: Name of the group<br>`participants`: Array of phone numbers to add                                                                                                |
-| `add_participants_to_group`   | Add participants to an existing group                   | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add                                                                                               |
-| `get_group_messages`          | Retrieve messages from a group                          | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve                                                                                          |
-| `send_group_message`          | Send a message to a group                               | `groupId`: ID of the group<br>`message`: Text content to send                                                                                                             |
-| `search_groups`               | Search for groups by name, description, or member names | `query`: Search term to find groups                                                                                                                                       |
-| `get_group_by_id`             | Get detailed information about a specific group         | `groupId`: ID of the group to get                                                                                                                                         |
-| `download_media_from_message` | Download media from a message                           | `messageId`: ID of the message containing media to download                                                                                                               |
-| `send_media_message`          | Send a media message to a WhatsApp contact              | `number`: Phone number to send to<br>`mediaType`: Source type (`url` or `local`)<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption for the media |
+| Tool                          | Description                                             | Parameters                                                                                        |
+| ----------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `get_status`                  | Check WhatsApp client connection status                 | None                                                                                              |
+| `send_message`                | Send messages to WhatsApp contacts                      | `number`: Phone number to send to<br>`message`: Text content to send                              |
+| `search_contacts`             | Search for contacts by name or number                   | `query`: Search term to find contacts                                                             |
+| `get_messages`                | Retrieve messages from a specific chat                  | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve |
+| `get_chats`                   | Get a list of all WhatsApp chats                        | None                                                                                              |
+| `create_group`                | Create a new WhatsApp group                             | `name`: Name of the group<br>`participants`: Array of phone numbers to add                        |
+| `add_participants_to_group`   | Add participants to an existing group                   | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add                       |
+| `get_group_messages`          | Retrieve messages from a group                          | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve                  |
+| `send_group_message`          | Send a message to a group                               | `groupId`: ID of the group<br>`message`: Text content to send                                     |
+| `search_groups`               | Search for groups by name, description, or member names | `query`: Search term to find groups                                                               |
+| `get_group_by_id`             | Get detailed information about a specific group         | `groupId`: ID of the group to get                                                                 |
+| `download_media_from_message` | Download media from a message                           | `messageId`: ID of the message containing media to download                                       |
 
 ### Available Resources
 
@@ -206,16 +205,15 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 
 #### Contacts & Messages
 
-| Endpoint                                   | Method | Description                    | Parameters                                                                                                                      |
-| ------------------------------------------ | ------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `/api/status`                              | GET    | Get WhatsApp connection status | None                                                                                                                            |
-| `/api/contacts`                            | GET    | Get all contacts               | None                                                                                                                            |
-| `/api/contacts/search`                     | GET    | Search for contacts            | `query`: Search term                                                                                                            |
-| `/api/chats`                               | GET    | Get all chats                  | None                                                                                                                            |
-| `/api/messages/{number}`                   | GET    | Get messages from a chat       | `limit` (query): Number of messages                                                                                             |
-| `/api/send`                                | POST   | Send a message                 | `number`: Recipient<br>`message`: Message content                                                                               |
-| `/api/send/media`                          | POST   | Send a media message           | `number`: Recipient<br>`mediaType`: `url` or `local`<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption |
-| `/api/messages/{messageId}/media/download` | POST   | Download media from a message  | None                                                                                                                            |
+| Endpoint                                   | Method | Description                    | Parameters                                        |
+| ------------------------------------------ | ------ | ------------------------------ | ------------------------------------------------- |
+| `/api/status`                              | GET    | Get WhatsApp connection status | None                                              |
+| `/api/contacts`                            | GET    | Get all contacts               | None                                              |
+| `/api/contacts/search`                     | GET    | Search for contacts            | `query`: Search term                              |
+| `/api/chats`                               | GET    | Get all chats                  | None                                              |
+| `/api/messages/{number}`                   | GET    | Get messages from a chat       | `limit` (query): Number of messages               |
+| `/api/send`                                | POST   | Send a message                 | `number`: Recipient<br>`message`: Message content |
+| `/api/messages/{messageId}/media/download` | POST   | Download media from a message  | None                                              |
 
 #### Group Management
 
@@ -433,11 +431,10 @@ This workflow requires an NPM_TOKEN secret to be configured in your GitHub repos
 - Group chat management
 - Contact management and search
 - Message history retrieval
-- Sending media messages (images only)
 
 ## Upcoming Features
 
-- Support for sending all media file types (video, audio, documents)
+- Support for sending media files (images, audio, documents)
 - Enhanced message templates for common scenarios
 - Advanced group management features
 - Contact management (add/remove contacts)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 | `search_groups`               | Search for groups by name, description, or member names | `query`: Search term to find groups                                                               |
 | `get_group_by_id`             | Get detailed information about a specific group         | `groupId`: ID of the group to get                                                                 |
 | `download_media_from_message` | Download media from a message                           | `messageId`: ID of the message containing media to download                                       |
+| `send_media_message`          | Send a media message to a WhatsApp contact              | `number`: Phone number to send to<br>`mediaType`: Source type (`url` or `local`)<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption for the media |
 
 ### Available Resources
 
@@ -213,6 +214,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 | `/api/chats`                               | GET    | Get all chats                  | None                                              |
 | `/api/messages/{number}`                   | GET    | Get messages from a chat       | `limit` (query): Number of messages               |
 | `/api/send`                                | POST   | Send a message                 | `number`: Recipient<br>`message`: Message content |
+| `/api/send/media`                          | POST   | Send a media message           | `number`: Recipient<br>`mediaType`: `url` or `local`<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption |
 | `/api/messages/{messageId}/media/download` | POST   | Download media from a message  | None                                              |
 
 #### Group Management
@@ -427,6 +429,7 @@ This workflow requires an NPM_TOKEN secret to be configured in your GitHub repos
 ## Features
 
 - Sending and receiving messages
+- Sending media messages (images only)
 - Downloading media from messages (images, audio, documents)
 - Group chat management
 - Contact management and search
@@ -434,7 +437,7 @@ This workflow requires an NPM_TOKEN secret to be configured in your GitHub repos
 
 ## Upcoming Features
 
-- Support for sending media files (images, audio, documents)
+- Support for sending all media file types (video, audio, documents)
 - Enhanced message templates for common scenarios
 - Advanced group management features
 - Contact management (add/remove contacts)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Node.js application that connects WhatsApp Web with AI models through the Mode
 ## Overview
 
 WhatsApp Web MCP provides a seamless integration between WhatsApp Web and AI models by:
+
 - Creating a standardized interface through the Model Context Protocol (MCP)
 - Offering MCP Server access to WhatsApp functionality
 - Providing flexible deployment options through SSE or Command modes
@@ -14,7 +15,7 @@ WhatsApp Web MCP provides a seamless integration between WhatsApp Web and AI mod
 
 ## Disclaimer
 
-**IMPORTANT**: This tool is for testing purposes only and should not be used in production environments. 
+**IMPORTANT**: This tool is for testing purposes only and should not be used in production environments.
 
 Disclaimer from WhatsApp Web project:
 
@@ -24,23 +25,24 @@ Disclaimer from WhatsApp Web project:
 
 To learn more about using WhatsApp Web MCP in real-world scenarios, check out these articles:
 
-* [**Integrating WhatsApp with AI: Guide to Setting Up a WhatsApp MCP server**](https://medium.com/@pnizer/integrating-whatsapp-with-ai-a-complete-guide-to-setting-up-whatsapp-web-mcp-with-claude-and-f7a2180dca78)  
-* [**Integrating OpenAI Agents Python SDK with Anthropic's MCP**](https://medium.com/@pnizer/integrating-openai-agents-python-sdk-with-anthropics-mcp-229c686d9033)
-
+- [**Integrating WhatsApp with AI: Guide to Setting Up a WhatsApp MCP server**](https://medium.com/@pnizer/integrating-whatsapp-with-ai-a-complete-guide-to-setting-up-whatsapp-web-mcp-with-claude-and-f7a2180dca78)
+- [**Integrating OpenAI Agents Python SDK with Anthropic's MCP**](https://medium.com/@pnizer/integrating-openai-agents-python-sdk-with-anthropics-mcp-229c686d9033)
 
 ## Installation
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/pnizer/wweb-mcp.git
    cd wweb-mcp
    ```
 
 2. Install globally or use with npx:
+
    ```bash
    # Install globally
    npm install -g .
-   
+
    # Or use with npx directly
    npx .
    ```
@@ -54,17 +56,17 @@ To learn more about using WhatsApp Web MCP in real-world scenarios, check out th
 
 ### Command Line Options
 
-| Option | Alias | Description | Choices | Default |
-|--------|-------|-------------|---------|---------|
-| `--mode` | `-m` | Run mode | `mcp`, `whatsapp-api` | `mcp` |
-| `--mcp-mode` | `-c` | MCP connection mode | `standalone`, `api` | `standalone` |
-| `--transport` | `-t` | MCP transport mode | `sse`, `command` | `sse` |
-| `--sse-port` | `-p` | Port for SSE server | - | `3002` |
-| `--api-port` | - | Port for WhatsApp API server | - | `3001` |
-| `--auth-data-path` | `-a` | Path to store authentication data | - | `.wwebjs_auth` |
-| `--auth-strategy` | `-s` | Authentication strategy | `local`, `none` | `local` |
-| `--api-base-url` | `-b` | API base URL for MCP when using api mode | - | `http://localhost:3001/api` |
-| `--api-key` | `-k` | API key for WhatsApp Web REST API when using api mode | - | `''` |
+| Option             | Alias | Description                                           | Choices               | Default                     |
+| ------------------ | ----- | ----------------------------------------------------- | --------------------- | --------------------------- |
+| `--mode`           | `-m`  | Run mode                                              | `mcp`, `whatsapp-api` | `mcp`                       |
+| `--mcp-mode`       | `-c`  | MCP connection mode                                   | `standalone`, `api`   | `standalone`                |
+| `--transport`      | `-t`  | MCP transport mode                                    | `sse`, `command`      | `sse`                       |
+| `--sse-port`       | `-p`  | Port for SSE server                                   | -                     | `7002`                      |
+| `--api-port`       | -     | Port for WhatsApp API server                          | -                     | `7001`                      |
+| `--auth-data-path` | `-a`  | Path to store authentication data                     | -                     | `.wwebjs_auth`              |
+| `--auth-strategy`  | `-s`  | Authentication strategy                               | `local`, `none`       | `local`                     |
+| `--api-base-url`   | `-b`  | API base URL for MCP when using api mode              | -                     | `http://localhost:7001/api` |
+| `--api-key`        | `-k`  | API key for WhatsApp Web REST API when using api mode | -                     | `''`                        |
 
 ### API Key Authentication
 
@@ -77,7 +79,7 @@ WhatsApp API key: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd
 To connect the MCP server to the WhatsApp API server, you need to provide this API key using the `--api-key` or `-k` option:
 
 ```bash
-npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api --api-key 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api --api-key 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 ```
 
 The API key is stored in the authentication data directory (specified by `--auth-data-path`) and persists between restarts of the WhatsApp API server.
@@ -85,11 +87,13 @@ The API key is stored in the authentication data directory (specified by `--auth
 ### Authentication Methods
 
 #### Local Authentication (Recommended)
+
 - Scan QR code once
 - Credentials persist between sessions
 - More stable for long-term operation
 
 #### No Authentication
+
 - Default method
 - Requires QR code scan on each startup
 - Suitable for testing and development
@@ -114,13 +118,13 @@ You can configure webhooks to receive incoming WhatsApp messages by creating a `
 
 #### Configuration Options
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `url` | String | The webhook endpoint URL where message data will be sent |
-| `authToken` | String (optional) | Authentication token to be included in the Authorization header as a Bearer token |
-| `filters.allowedNumbers` | Array (optional) | List of phone numbers to accept messages from. If provided, only messages from these numbers will trigger the webhook |
-| `filters.allowPrivate` | Boolean (optional) | Whether to send private messages to the webhook. Default: `true` |
-| `filters.allowGroups` | Boolean (optional) | Whether to send group messages to the webhook. Default: `true` |
+| Option                   | Type               | Description                                                                                                           |
+| ------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `url`                    | String             | The webhook endpoint URL where message data will be sent                                                              |
+| `authToken`              | String (optional)  | Authentication token to be included in the Authorization header as a Bearer token                                     |
+| `filters.allowedNumbers` | Array (optional)   | List of phone numbers to accept messages from. If provided, only messages from these numbers will trigger the webhook |
+| `filters.allowPrivate`   | Boolean (optional) | Whether to send private messages to the webhook. Default: `true`                                                      |
+| `filters.allowGroups`    | Boolean (optional) | Whether to send group messages to the webhook. Default: `true`                                                        |
 
 #### Webhook Payload
 
@@ -142,78 +146,86 @@ When a message is received and passes the filters, a POST request will be sent t
 ### Running Modes
 
 #### WhatsApp API Server
+
 Run a standalone WhatsApp API server that exposes WhatsApp functionality through REST endpoints:
+
 ```bash
-npx wweb-mcp --mode whatsapp-api --api-port 3001
+npx wweb-mcp --mode whatsapp-api --api-port 7001
 ```
 
 #### MCP Server (Standalone)
+
 Run an MCP server that directly connects to WhatsApp Web:
+
 ```bash
-npx wweb-mcp --mode mcp --mcp-mode standalone --transport sse --sse-port 3002
+npx wweb-mcp --mode mcp --mcp-mode standalone --transport sse --sse-port 7002
 ```
 
 #### MCP Server (API Client)
+
 Run an MCP server that connects to the WhatsApp API server:
+
 ```bash
 # First, start the WhatsApp API server and note the API key from the logs
-npx wweb-mcp --mode whatsapp-api --api-port 3001
+npx wweb-mcp --mode whatsapp-api --api-port 7001
 
 # Then, start the MCP server with the API key
-npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api --api-key YOUR_API_KEY --transport sse --sse-port 3002
+npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:7001/api --api-key YOUR_API_KEY --transport sse --sse-port 7002
 ```
 
 ### Available Tools
 
-| Tool | Description | Parameters |
-|------|-------------|------------|
-| `get_status` | Check WhatsApp client connection status | None |
-| `send_message` | Send messages to WhatsApp contacts | `number`: Phone number to send to<br>`message`: Text content to send |
-| `search_contacts` | Search for contacts by name or number | `query`: Search term to find contacts |
-| `get_messages` | Retrieve messages from a specific chat | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve |
-| `get_chats` | Get a list of all WhatsApp chats | None |
-| `create_group` | Create a new WhatsApp group | `name`: Name of the group<br>`participants`: Array of phone numbers to add |
-| `add_participants_to_group` | Add participants to an existing group | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add |
-| `get_group_messages` | Retrieve messages from a group | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve |
-| `send_group_message` | Send a message to a group | `groupId`: ID of the group<br>`message`: Text content to send |
-| `search_groups` | Search for groups by name, description, or member names | `query`: Search term to find groups |
-| `get_group_by_id` | Get detailed information about a specific group | `groupId`: ID of the group to get |
-| `download_media_from_message` | Download media from a message | `messageId`: ID of the message containing media to download |
+| Tool                          | Description                                             | Parameters                                                                                        |
+| ----------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `get_status`                  | Check WhatsApp client connection status                 | None                                                                                              |
+| `send_message`                | Send messages to WhatsApp contacts                      | `number`: Phone number to send to<br>`message`: Text content to send                              |
+| `search_contacts`             | Search for contacts by name or number                   | `query`: Search term to find contacts                                                             |
+| `get_messages`                | Retrieve messages from a specific chat                  | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve |
+| `get_chats`                   | Get a list of all WhatsApp chats                        | None                                                                                              |
+| `create_group`                | Create a new WhatsApp group                             | `name`: Name of the group<br>`participants`: Array of phone numbers to add                        |
+| `add_participants_to_group`   | Add participants to an existing group                   | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add                       |
+| `get_group_messages`          | Retrieve messages from a group                          | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve                  |
+| `send_group_message`          | Send a message to a group                               | `groupId`: ID of the group<br>`message`: Text content to send                                     |
+| `search_groups`               | Search for groups by name, description, or member names | `query`: Search term to find groups                                                               |
+| `get_group_by_id`             | Get detailed information about a specific group         | `groupId`: ID of the group to get                                                                 |
+| `download_media_from_message` | Download media from a message                           | `messageId`: ID of the message containing media to download                                       |
 
 ### Available Resources
 
-| Resource URI | Description |
-|--------------|-------------|
-| `whatsapp://contacts` | List of all WhatsApp contacts |
-| `whatsapp://messages/{number}` | Messages from a specific chat |
-| `whatsapp://chats` | List of all WhatsApp chats |
-| `whatsapp://groups` | List of all WhatsApp groups |
-| `whatsapp://groups/search` | Search for groups by name, description, or member names |
-| `whatsapp://groups/{groupId}/messages` | Messages from a specific group |
+| Resource URI                           | Description                                             |
+| -------------------------------------- | ------------------------------------------------------- |
+| `whatsapp://contacts`                  | List of all WhatsApp contacts                           |
+| `whatsapp://messages/{number}`         | Messages from a specific chat                           |
+| `whatsapp://chats`                     | List of all WhatsApp chats                              |
+| `whatsapp://groups`                    | List of all WhatsApp groups                             |
+| `whatsapp://groups/search`             | Search for groups by name, description, or member names |
+| `whatsapp://groups/{groupId}/messages` | Messages from a specific group                          |
 
 ### REST API Endpoints
 
 #### Contacts & Messages
-| Endpoint | Method | Description | Parameters |
-|----------|--------|-------------|------------|
-| `/api/status` | GET | Get WhatsApp connection status | None |
-| `/api/contacts` | GET | Get all contacts | None |
-| `/api/contacts/search` | GET | Search for contacts | `query`: Search term |
-| `/api/chats` | GET | Get all chats | None |
-| `/api/messages/{number}` | GET | Get messages from a chat | `limit` (query): Number of messages |
-| `/api/send` | POST | Send a message | `number`: Recipient<br>`message`: Message content |
-| `/api/messages/{messageId}/media/download` | POST | Download media from a message | None |
+
+| Endpoint                                   | Method | Description                    | Parameters                                        |
+| ------------------------------------------ | ------ | ------------------------------ | ------------------------------------------------- |
+| `/api/status`                              | GET    | Get WhatsApp connection status | None                                              |
+| `/api/contacts`                            | GET    | Get all contacts               | None                                              |
+| `/api/contacts/search`                     | GET    | Search for contacts            | `query`: Search term                              |
+| `/api/chats`                               | GET    | Get all chats                  | None                                              |
+| `/api/messages/{number}`                   | GET    | Get messages from a chat       | `limit` (query): Number of messages               |
+| `/api/send`                                | POST   | Send a message                 | `number`: Recipient<br>`message`: Message content |
+| `/api/messages/{messageId}/media/download` | POST   | Download media from a message  | None                                              |
 
 #### Group Management
-| Endpoint | Method | Description | Parameters |
-|----------|--------|-------------|------------|
-| `/api/groups` | GET | Get all groups | None |
-| `/api/groups/search` | GET | Search for groups | `query`: Search term |
-| `/api/groups/create` | POST | Create a new group | `name`: Group name<br>`participants`: Array of numbers |
-| `/api/groups/{groupId}` | GET | Get detailed information about a specific group | None |
-| `/api/groups/{groupId}/messages` | GET | Get messages from a group | `limit` (query): Number of messages |
-| `/api/groups/{groupId}/participants/add` | POST | Add members to a group | `participants`: Array of numbers |
-| `/api/groups/send` | POST | Send a message to a group | `groupId`: Group ID<br>`message`: Message content |
+
+| Endpoint                                 | Method | Description                                     | Parameters                                             |
+| ---------------------------------------- | ------ | ----------------------------------------------- | ------------------------------------------------------ |
+| `/api/groups`                            | GET    | Get all groups                                  | None                                                   |
+| `/api/groups/search`                     | GET    | Search for groups                               | `query`: Search term                                   |
+| `/api/groups/create`                     | POST   | Create a new group                              | `name`: Group name<br>`participants`: Array of numbers |
+| `/api/groups/{groupId}`                  | GET    | Get detailed information about a specific group | None                                                   |
+| `/api/groups/{groupId}/messages`         | GET    | Get messages from a group                       | `limit` (query): Number of messages                    |
+| `/api/groups/{groupId}/participants/add` | POST   | Add members to a group                          | `participants`: Array of numbers                       |
+| `/api/groups/send`                       | POST   | Send a message to a group                       | `groupId`: Group ID<br>`message`: Message content      |
 
 ### AI Integration
 
@@ -222,6 +234,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 ##### Option 1: Using NPX
 
 1. Start WhatsApp API server:
+
    ```bash
    npx wweb-mcp -m whatsapp-api -s local
    ```
@@ -229,6 +242,7 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 2. Scan the QR code with your WhatsApp mobile app
 
 3. Note the API key displayed in the logs:
+
    ```
    WhatsApp API key: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
    ```
@@ -236,57 +250,72 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 4. Add the following to your Claude Desktop configuration:
    ```json
    {
-       "mcpServers": {
-           "whatsapp": {
-               "command": "npx",
-               "args": [
-                   "wweb-mcp",
-                   "-m", "mcp",
-                   "-s", "local",
-                   "-c", "api",
-                   "-t", "command",
-                   "--api-base-url", "http://localhost:3001/api",
-                   "--api-key", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-               ]
-           }
+     "mcpServers": {
+       "whatsapp": {
+         "command": "npx",
+         "args": [
+           "wweb-mcp",
+           "-m",
+           "mcp",
+           "-s",
+           "local",
+           "-c",
+           "api",
+           "-t",
+           "command",
+           "--api-base-url",
+           "http://localhost:7001/api",
+           "--api-key",
+           "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+         ]
        }
+     }
    }
    ```
 
 ##### Option 2: Using Docker
 
 1. Start WhatsApp API server in Docker:
+
    ```bash
-   docker run -i -p 3001:3001 -v wweb-mcp:/wwebjs_auth --rm wweb-mcp:latest -m whatsapp-api -s local -a /wwebjs_auth
+   docker run -i -p 7001:7001 -v wweb-mcp:/wwebjs_auth --rm wweb-mcp:latest -m whatsapp-api -s local -a /wwebjs_auth
    ```
 
 2. Scan the QR code with your WhatsApp mobile app
 
 3. Note the API key displayed in the logs:
+
    ```
    WhatsApp API key: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
    ```
 
 4. Add the following to your Claude Desktop configuration:
+
    ```json
    {
-       "mcpServers": {
-           "whatsapp": {
-               "command": "docker",
-               "args": [
-                   "run",
-                   "-i",
-                   "--rm",
-                   "wweb-mcp:latest",
-                   "-m", "mcp",
-                   "-s", "local",
-                   "-c", "api",
-                   "-t", "command",
-                   "--api-base-url", "http://host.docker.internal:3001/api",
-                   "--api-key", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-               ]
-           }
+     "mcpServers": {
+       "whatsapp": {
+         "command": "docker",
+         "args": [
+           "run",
+           "-i",
+           "--rm",
+           "wweb-mcp:latest",
+           "-m",
+           "mcp",
+           "-s",
+           "local",
+           "-c",
+           "api",
+           "-t",
+           "command",
+           "--api-base-url",
+           "http://host.docker.internal:7001/api",
+           "--api-key",
+           "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+         ]
        }
+     }
    }
    ```
 
@@ -311,6 +340,7 @@ The project is structured with a clean separation of concerns:
 3. **MCP Server (API Client)**: Connection to WhatsApp API server
 
 This architecture allows for flexible deployment scenarios, including:
+
 - Running the API server and MCP server on different machines
 - Using the MCP server as a client to an existing API server
 - Running everything on a single machine for simplicity
@@ -330,6 +360,7 @@ src/
 ```
 
 ### Building from Source
+
 ```bash
 npm run build
 ```
@@ -390,7 +421,8 @@ This workflow requires an NPM_TOKEN secret to be configured in your GitHub repos
 ## Troubleshooting
 
 ### Claude Desktop Integration Issues
-   - It's not possible to start wweb-mcp in command standalone mode on Claude because Claude opens more than one process, multiple times, and each wweb-mcp needs to open a puppeteer session that cannot share the same WhatsApp authentication. Because of this limitation, we've split the app into MCP and API modes to allow for proper integration with Claude.
+
+- It's not possible to start wweb-mcp in command standalone mode on Claude because Claude opens more than one process, multiple times, and each wweb-mcp needs to open a puppeteer session that cannot share the same WhatsApp authentication. Because of this limitation, we've split the app into MCP and API modes to allow for proper integration with Claude.
 
 ## Features
 
@@ -417,6 +449,7 @@ This workflow requires an NPM_TOKEN secret to be configured in your GitHub repos
 5. Create a Pull Request
 
 Please ensure your PR:
+
 - Follows the existing code style
 - Includes appropriate tests
 - Updates documentation as needed

--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ To learn more about using WhatsApp Web MCP in real-world scenarios, check out th
 
 ### Command Line Options
 
-| Option             | Alias | Description                                           | Choices               | Default                     |
-| ------------------ | ----- | ----------------------------------------------------- | --------------------- | --------------------------- |
-| `--mode`           | `-m`  | Run mode                                              | `mcp`, `whatsapp-api` | `mcp`                       |
-| `--mcp-mode`       | `-c`  | MCP connection mode                                   | `standalone`, `api`   | `standalone`                |
-| `--transport`      | `-t`  | MCP transport mode                                    | `sse`, `command`      | `sse`                       |
-| `--sse-port`       | `-p`  | Port for SSE server                                   | -                     | `3002`                      |
-| `--api-port`       | -     | Port for WhatsApp API server                          | -                     | `3001`                      |
-| `--auth-data-path` | `-a`  | Path to store authentication data                     | -                     | `.wwebjs_auth`              |
-| `--auth-strategy`  | `-s`  | Authentication strategy                               | `local`, `none`       | `local`                     |
-| `--api-base-url`   | `-b`  | API base URL for MCP when using api mode              | -                     | `http://localhost:3001/api` |
-| `--api-key`        | `-k`  | API key for WhatsApp Web REST API when using api mode | -                     | `''`                        |
+| Option | Alias | Description | Choices | Default |
+|--------|-------|-------------|---------|---------|
+| `--mode` | `-m` | Run mode | `mcp`, `whatsapp-api` | `mcp` |
+| `--mcp-mode` | `-c` | MCP connection mode | `standalone`, `api` | `standalone` |
+| `--transport` | `-t` | MCP transport mode | `sse`, `command` | `sse` |
+| `--sse-port` | `-p` | Port for SSE server | - | `3002` |
+| `--api-port` | - | Port for WhatsApp API server | - | `3001` |
+| `--auth-data-path` | `-a` | Path to store authentication data | - | `.wwebjs_auth` |
+| `--auth-strategy` | `-s` | Authentication strategy | `local`, `none` | `local` |
+| `--api-base-url` | `-b` | API base URL for MCP when using api mode | - | `http://localhost:3001/api` |
+| `--api-key` | `-k` | API key for WhatsApp Web REST API when using api mode | - | `''` |
 
 ### API Key Authentication
 
@@ -118,13 +118,13 @@ You can configure webhooks to receive incoming WhatsApp messages by creating a `
 
 #### Configuration Options
 
-| Option                   | Type               | Description                                                                                                           |
-| ------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| `url`                    | String             | The webhook endpoint URL where message data will be sent                                                              |
-| `authToken`              | String (optional)  | Authentication token to be included in the Authorization header as a Bearer token                                     |
-| `filters.allowedNumbers` | Array (optional)   | List of phone numbers to accept messages from. If provided, only messages from these numbers will trigger the webhook |
-| `filters.allowPrivate`   | Boolean (optional) | Whether to send private messages to the webhook. Default: `true`                                                      |
-| `filters.allowGroups`    | Boolean (optional) | Whether to send group messages to the webhook. Default: `true`                                                        |
+| Option | Type | Description |
+|--------|------|-------------|
+| `url` | String | The webhook endpoint URL where message data will be sent |
+| `authToken` | String (optional) | Authentication token to be included in the Authorization header as a Bearer token |
+| `filters.allowedNumbers` | Array (optional) | List of phone numbers to accept messages from. If provided, only messages from these numbers will trigger the webhook |
+| `filters.allowPrivate` | Boolean (optional) | Whether to send private messages to the webhook. Default: `true` |
+| `filters.allowGroups` | Boolean (optional) | Whether to send group messages to the webhook. Default: `true` |
 
 #### Webhook Payload
 
@@ -175,59 +175,60 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 
 ### Available Tools
 
-| Tool                          | Description                                             | Parameters                                                                                        |
-| ----------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `get_status`                  | Check WhatsApp client connection status                 | None                                                                                              |
-| `send_message`                | Send messages to WhatsApp contacts                      | `number`: Phone number to send to<br>`message`: Text content to send                              |
-| `search_contacts`             | Search for contacts by name or number                   | `query`: Search term to find contacts                                                             |
-| `get_messages`                | Retrieve messages from a specific chat                  | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve |
-| `get_chats`                   | Get a list of all WhatsApp chats                        | None                                                                                              |
-| `create_group`                | Create a new WhatsApp group                             | `name`: Name of the group<br>`participants`: Array of phone numbers to add                        |
-| `add_participants_to_group`   | Add participants to an existing group                   | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add                       |
-| `get_group_messages`          | Retrieve messages from a group                          | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve                  |
-| `send_group_message`          | Send a message to a group                               | `groupId`: ID of the group<br>`message`: Text content to send                                     |
-| `search_groups`               | Search for groups by name, description, or member names | `query`: Search term to find groups                                                               |
-| `get_group_by_id`             | Get detailed information about a specific group         | `groupId`: ID of the group to get                                                                 |
-| `download_media_from_message` | Download media from a message                           | `messageId`: ID of the message containing media to download                                       |
-| `send_media_message`          | Send a media message to a WhatsApp contact              | `number`: Phone number to send to<br>`mediaType`: Source type (`url` or `local`)<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption for the media |
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `get_status` | Check WhatsApp client connection status | None |
+| `send_message` | Send messages to WhatsApp contacts | `number`: Phone number to send to<br>`message`: Text content to send |
+| `search_contacts` | Search for contacts by name or number | `query`: Search term to find contacts |
+| `get_messages` | Retrieve messages from a specific chat | `number`: Phone number to get messages from<br>`limit` (optional): Number of messages to retrieve |
+| `get_chats` | Get a list of all WhatsApp chats | None |
+| `create_group` | Create a new WhatsApp group | `name`: Name of the group<br>`participants`: Array of phone numbers to add |
+| `add_participants_to_group` | Add participants to an existing group | `groupId`: ID of the group<br>`participants`: Array of phone numbers to add |
+| `get_group_messages` | Retrieve messages from a group | `groupId`: ID of the group<br>`limit` (optional): Number of messages to retrieve |
+| `send_group_message` | Send a message to a group | `groupId`: ID of the group<br>`message`: Text content to send |
+| `search_groups` | Search for groups by name, description, or member names | `query`: Search term to find groups |
+| `get_group_by_id` | Get detailed information about a specific group | `groupId`: ID of the group to get |
+| `download_media_from_message` | Download media from a message | `messageId`: ID of the message containing media to download |
+| `send_media_message` | Send a media message to a WhatsApp contact | `number`: Phone number to send to<br>`mediaType`: Source type (`url` or `local`)<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption for the media |
 
 ### Available Resources
 
-| Resource URI                           | Description                                             |
-| -------------------------------------- | ------------------------------------------------------- |
-| `whatsapp://contacts`                  | List of all WhatsApp contacts                           |
-| `whatsapp://messages/{number}`         | Messages from a specific chat                           |
-| `whatsapp://chats`                     | List of all WhatsApp chats                              |
-| `whatsapp://groups`                    | List of all WhatsApp groups                             |
-| `whatsapp://groups/search`             | Search for groups by name, description, or member names |
-| `whatsapp://groups/{groupId}/messages` | Messages from a specific group                          |
+| Resource URI | Description |
+|--------------|-------------|
+| `whatsapp://contacts` | List of all WhatsApp contacts |
+| `whatsapp://messages/{number}` | Messages from a specific chat |
+| `whatsapp://chats` | List of all WhatsApp chats |
+| `whatsapp://groups` | List of all WhatsApp groups |
+| `whatsapp://groups/search` | Search for groups by name, description, or member names |
+| `whatsapp://groups/{groupId}/messages` | Messages from a specific group |
 
 ### REST API Endpoints
 
 #### Contacts & Messages
 
-| Endpoint                                   | Method | Description                    | Parameters                                        |
-| ------------------------------------------ | ------ | ------------------------------ | ------------------------------------------------- |
-| `/api/status`                              | GET    | Get WhatsApp connection status | None                                              |
-| `/api/contacts`                            | GET    | Get all contacts               | None                                              |
-| `/api/contacts/search`                     | GET    | Search for contacts            | `query`: Search term                              |
-| `/api/chats`                               | GET    | Get all chats                  | None                                              |
-| `/api/messages/{number}`                   | GET    | Get messages from a chat       | `limit` (query): Number of messages               |
-| `/api/send`                                | POST   | Send a message                 | `number`: Recipient<br>`message`: Message content |
-| `/api/send/media`                          | POST   | Send a media message           | `number`: Recipient<br>`mediaType`: `url` or `local`<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption |
-| `/api/messages/{messageId}/media/download` | POST   | Download media from a message  | None                                              |
+| Endpoint | Method | Description | Parameters |
+|----------|--------|-------------|------------|
+| `/api/status` | GET | Get WhatsApp connection status | None |
+| `/api/contacts` | GET | Get all contacts | None |
+| `/api/contacts/search` | GET | Search for contacts | `query`: Search term |
+| `/api/chats` | GET | Get all chats | None |
+| `/api/messages/{number}` | GET | Get messages from a chat | `limit` (query): Number of messages |
+| `/api/send` | POST | Send a message | `number`: Recipient<br>`message`: Message content |
+| `/api/send/media` | POST | Send a media message | `number`: Recipient<br>`mediaType`: `url` or `local`<br>`mediaLocation`: URL or file path<br>`caption` (optional): Text caption |
+| `/api/messages/{messageId}/media/download` | POST | Download media from a message | None |
 
 #### Group Management
 
-| Endpoint                                 | Method | Description                                     | Parameters                                             |
-| ---------------------------------------- | ------ | ----------------------------------------------- | ------------------------------------------------------ |
-| `/api/groups`                            | GET    | Get all groups                                  | None                                                   |
-| `/api/groups/search`                     | GET    | Search for groups                               | `query`: Search term                                   |
-| `/api/groups/create`                     | POST   | Create a new group                              | `name`: Group name<br>`participants`: Array of numbers |
-| `/api/groups/{groupId}`                  | GET    | Get detailed information about a specific group | None                                                   |
-| `/api/groups/{groupId}/messages`         | GET    | Get messages from a group                       | `limit` (query): Number of messages                    |
-| `/api/groups/{groupId}/participants/add` | POST   | Add members to a group                          | `participants`: Array of numbers                       |
-| `/api/groups/send`                       | POST   | Send a message to a group                       | `groupId`: Group ID<br>`message`: Message content      |
+| Endpoint | Method | Description | Parameters |
+|----------|--------|-------------|------------|
+| `/api/groups` | GET | Get all groups | None |
+| `/api/groups/search` | GET | Search for groups | `query`: Search term |
+| `/api/groups/create` | POST | Create a new group | `name`: Group name<br>`participants`: Array of numbers |
+| `/api/groups/{groupId}` | GET | Get detailed information about a specific group | None |
+| `/api/groups/{groupId}/messages` | GET | Get messages from a group | `limit` (query): Number of messages |
+| `/api/groups/{groupId}/participants/add` | POST | Add members to a group | `participants`: Array of numbers |
+| `/api/groups/send` | POST | Send a message to a group | `groupId`: Group ID<br>`message`: Message content |
 
 ### AI Integration
 
@@ -252,26 +253,20 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 4. Add the following to your Claude Desktop configuration:
    ```json
    {
-     "mcpServers": {
-       "whatsapp": {
-         "command": "npx",
-         "args": [
-           "wweb-mcp",
-           "-m",
-           "mcp",
-           "-s",
-           "local",
-           "-c",
-           "api",
-           "-t",
-           "command",
-           "--api-base-url",
-           "http://localhost:3001/api",
-           "--api-key",
-           "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-         ]
+       "mcpServers": {
+           "whatsapp": {
+               "command": "npx",
+               "args": [
+                   "wweb-mcp",
+                   "-m", "mcp",
+                   "-s", "local",
+                   "-c", "api",
+                   "-t", "command",
+                   "--api-base-url", "http://localhost:3001/api",
+                   "--api-key", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+               ]
+           }
        }
-     }
    }
    ```
 
@@ -295,29 +290,23 @@ npx wweb-mcp --mode mcp --mcp-mode api --api-base-url http://localhost:3001/api 
 
    ```json
    {
-     "mcpServers": {
-       "whatsapp": {
-         "command": "docker",
-         "args": [
-           "run",
-           "-i",
-           "--rm",
-           "wweb-mcp:latest",
-           "-m",
-           "mcp",
-           "-s",
-           "local",
-           "-c",
-           "api",
-           "-t",
-           "command",
-           "--api-base-url",
-           "http://host.docker.internal:3001/api",
-           "--api-key",
-           "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-         ]
+       "mcpServers": {
+           "whatsapp": {
+               "command": "docker",
+               "args": [
+                   "run",
+                   "-i",
+                   "--rm",
+                   "wweb-mcp:latest",
+                   "-m", "mcp",
+                   "-s", "local",
+                   "-c", "api",
+                   "-t", "command",
+                   "--api-base-url", "http://host.docker.internal:3001/api",
+                   "--api-key", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+               ]
+           }
        }
-     }
    }
    ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
-        "@types/jest": "^29.5.12",
+        "@types/jest": "^29.5.14",
         "@types/mime-types": "^2.1.4",
-        "@types/node": "^20.13.1",
+        "@types/node": "^20.17.28",
         "@types/qrcode-terminal": "^0.12.2",
         "@types/supertest": "^6.0.2",
         "@types/yargs": "^17.0.33",
@@ -1491,6 +1491,7 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -1521,10 +1522,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.17.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
-      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
-    "@types/jest": "^29.5.12",
+    "@types/jest": "^29.5.14",
     "@types/mime-types": "^2.1.4",
-    "@types/node": "^20.13.1",
+    "@types/node": "^20.17.28",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/supertest": "^6.0.2",
     "@types/yargs": "^17.0.33",

--- a/src/api.ts
+++ b/src/api.ts
@@ -670,22 +670,17 @@ export function routerFactory(client: Client): Router {
    *             type: object
    *             required:
    *               - number
-   *               - mediaType
-   *               - mediaLocation
+   *               - source
    *             properties:
    *               number:
    *                 type: string
    *                 description: The phone number to send the message to
-   *               mediaType:
+   *               source:
    *                 type: string
-   *                 enum: [url, local]
-   *                 description: Whether the media is from a URL or local file
-   *               mediaLocation:
-   *                 type: string
-   *                 description: The URL or local file path of the image
+   *                 description: The source of the media - URLs must use http:// or https:// prefixes, local files must use file:// prefix (e.g., 'https://example.com/image.jpg' or 'file:///path/to/image.jpg')
    *               caption:
    *                 type: string
-   *                 description: Optional caption for the image
+   *                 description: caption for the media
    *     responses:
    *       200:
    *         description: Media message sent successfully
@@ -698,24 +693,17 @@ export function routerFactory(client: Client): Router {
    */
   router.post('/send/media', async (req: Request, res: Response) => {
     try {
-      const { number, mediaType, mediaLocation, caption } = req.body;
+      const { number, source, caption = '' } = req.body;
 
       // Validate required parameters
-      if (!number || !mediaType || !mediaLocation) {
-        res.status(400).json({ error: 'Number, mediaType, and mediaLocation are required' });
-        return;
-      }
-
-      // Validate mediaType
-      if (mediaType !== 'url' && mediaType !== 'local') {
-        res.status(400).json({ error: 'mediaType must be either "url" or "local"' });
+      if (!number || !source) {
+        res.status(400).json({ error: 'Number and source are required' });
         return;
       }
 
       const result = await whatsappService.sendMediaMessage({
         number,
-        mediaType,
-        mediaLocation,
+        source,
         caption,
       });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ function parseCommandLineArgs(): ReturnType<typeof yargs.parseSync> {
     .option('api-port', {
       description: 'Port for WhatsApp API server',
       type: 'number',
-      default: 7001,
+      default: 3001,
     })
     .option('auth-data-path', {
       alias: 'a',
@@ -67,7 +67,7 @@ function parseCommandLineArgs(): ReturnType<typeof yargs.parseSync> {
       alias: 'b',
       description: 'Base URL for WhatsApp Web REST API when using api mode',
       type: 'string',
-      default: 'http://localhost:7001/api',
+      default: 'http://localhost:3001/api',
     })
     .option('api-key', {
       alias: 'k',

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ function parseCommandLineArgs(): ReturnType<typeof yargs.parseSync> {
       alias: 'p',
       description: 'Port for SSE server',
       type: 'number',
-      default: 7002,
+      default: 3002,
     })
     .option('api-port', {
       description: 'Port for WhatsApp API server',

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,12 +43,12 @@ function parseCommandLineArgs(): ReturnType<typeof yargs.parseSync> {
       alias: 'p',
       description: 'Port for SSE server',
       type: 'number',
-      default: 3002,
+      default: 7002,
     })
     .option('api-port', {
       description: 'Port for WhatsApp API server',
       type: 'number',
-      default: 3001,
+      default: 7001,
     })
     .option('auth-data-path', {
       alias: 'a',
@@ -67,7 +67,7 @@ function parseCommandLineArgs(): ReturnType<typeof yargs.parseSync> {
       alias: 'b',
       description: 'Base URL for WhatsApp Web REST API when using api mode',
       type: 'string',
-      default: 'http://localhost:3001/api',
+      default: 'http://localhost:7001/api',
     })
     .option('api-key', {
       alias: 'k',

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -591,16 +591,14 @@ export function createMcpServer(config: McpConfig = {}, client: Client | null = 
     'send_media_message',
     {
       number: z.string().describe('The phone number to send the message to'),
-      mediaType: z.enum(['url', 'local']).describe('Whether the media is from a URL or local file'),
-      mediaLocation: z.string().describe('The URL or local file path of the image'),
-      caption: z.string().default('').describe('Caption for the image'),
+      source: z.string().describe('The source of the media - URLs must use http:// or https:// prefixes, local files must use file:// prefix'),
+      caption: z.string().default('').describe('Caption for the media'),
     },
-    async ({ number, mediaType, mediaLocation, caption }) => {
+    async ({ number, source, caption }) => {
       try {
         const result = await service.sendMediaMessage({
           number,
-          mediaType,
-          mediaLocation,
+          source,
           caption,
         });
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -593,7 +593,7 @@ export function createMcpServer(config: McpConfig = {}, client: Client | null = 
       number: z.string().describe('The phone number to send the message to'),
       mediaType: z.enum(['url', 'local']).describe('Whether the media is from a URL or local file'),
       mediaLocation: z.string().describe('The URL or local file path of the image'),
-      caption: z.string().optional().describe('Optional caption for the image'),
+      caption: z.string().default('').describe('Caption for the image'),
     },
     async ({ number, mediaType, mediaLocation, caption }) => {
       try {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -586,5 +586,45 @@ export function createMcpServer(config: McpConfig = {}, client: Client | null = 
     },
   );
 
+  // Tool to send a media message
+  server.tool(
+    'send_media_message',
+    {
+      number: z.string().describe('The phone number to send the message to'),
+      mediaType: z.enum(['url', 'local']).describe('Whether the media is from a URL or local file'),
+      mediaLocation: z.string().describe('The URL or local file path of the image'),
+      caption: z.string().optional().describe('Optional caption for the image'),
+    },
+    async ({ number, mediaType, mediaLocation, caption }) => {
+      try {
+        const result = await service.sendMediaMessage({
+          number,
+          mediaType,
+          mediaLocation,
+          caption,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Media message sent successfully to ${number}.\nMessage ID: ${result.messageId}\nMedia Info:\n${JSON.stringify(result.mediaInfo, null, 2)}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error sending media message: ${error}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
   return server;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,3 +63,18 @@ export interface MediaResponse {
   filesize: number;
   messageId: string;
 }
+
+export interface SendMediaMessageParams {
+  number: string;
+  mediaType: 'url' | 'local';
+  mediaLocation: string;
+  caption?: string;
+}
+
+export interface SendMediaMessageResponse extends SendMessageResponse {
+  mediaInfo: {
+    mimetype: string;
+    filename: string;
+    size?: number;
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export interface SendMediaMessageParams {
   number: string;
   mediaType: 'url' | 'local';
   mediaLocation: string;
-  caption?: string;
+  caption: string;
 }
 
 export interface SendMediaMessageResponse extends SendMessageResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,9 +66,8 @@ export interface MediaResponse {
 
 export interface SendMediaMessageParams {
   number: string;
-  mediaType: 'url' | 'local';
-  mediaLocation: string;
-  caption: string;
+  source: string;  // URI scheme format: URLs must use http:// or https:// prefixes, local files must use file:// prefix
+  caption?: string;
 }
 
 export interface SendMediaMessageResponse extends SendMessageResponse {

--- a/src/whatsapp-api-client.ts
+++ b/src/whatsapp-api-client.ts
@@ -9,6 +9,8 @@ import {
   CreateGroupResponse,
   AddParticipantsResponse,
   MediaResponse,
+  SendMediaMessageParams,
+  SendMediaMessageResponse,
 } from './types';
 
 // Helper function to convert errors to strings
@@ -179,6 +181,25 @@ export class WhatsAppApiClient {
       return response.data;
     } catch (error) {
       throw new Error(`Failed to download media from message: ${errorToString(error)}`);
+    }
+  }
+
+  async sendMediaMessage({
+    number,
+    mediaType,
+    mediaLocation,
+    caption,
+  }: SendMediaMessageParams): Promise<SendMediaMessageResponse> {
+    try {
+      const response = await this.axiosInstance.post('/send/media', {
+        number,
+        mediaType,
+        mediaLocation,
+        caption,
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to send media message: ${errorToString(error)}`);
     }
   }
 }

--- a/src/whatsapp-api-client.ts
+++ b/src/whatsapp-api-client.ts
@@ -186,15 +186,13 @@ export class WhatsAppApiClient {
 
   async sendMediaMessage({
     number,
-    mediaType,
-    mediaLocation,
+    source,
     caption,
   }: SendMediaMessageParams): Promise<SendMediaMessageResponse> {
     try {
       const response = await this.axiosInstance.post('/send/media', {
         number,
-        mediaType,
-        mediaLocation,
+        source,
         caption,
       });
       return response.data;

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -544,8 +544,7 @@ describe('API Router', () => {
         .post('/api/send/media')
         .send({
           number: '1234567890',
-          mediaType: 'url',
-          mediaLocation: 'https://example.com/image.jpg',
+          source: 'https://example.com/image.jpg',
           caption: 'Test caption'
         });
 
@@ -553,8 +552,7 @@ describe('API Router', () => {
       expect(response.body).toEqual(mockResult);
       expect(mockWhatsAppService.sendMediaMessage).toHaveBeenCalledWith({
         number: '1234567890',
-        mediaType: 'url',
-        mediaLocation: 'https://example.com/image.jpg',
+        source: 'https://example.com/image.jpg',
         caption: 'Test caption'
       });
     });
@@ -564,7 +562,7 @@ describe('API Router', () => {
         .post('/api/send/media')
         .send({
           number: '1234567890',
-          // missing mediaType and mediaLocation
+          // missing source
         });
 
       expect(response.status).toBe(400);
@@ -572,18 +570,19 @@ describe('API Router', () => {
       expect(mockWhatsAppService.sendMediaMessage).not.toHaveBeenCalled();
     });
 
-    it('should handle invalid media type', async () => {
+    it('should handle invalid source format', async () => {
+      mockWhatsAppService.sendMediaMessage.mockRejectedValue(new Error('Invalid source format'));
+
       const response = await request(app)
         .post('/api/send/media')
         .send({
           number: '1234567890',
-          mediaType: 'invalid',
-          mediaLocation: 'https://example.com/image.jpg'
+          source: 'invalid-format-without-scheme'
         });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(500);
       expect(response.body).toHaveProperty('error');
-      expect(mockWhatsAppService.sendMediaMessage).not.toHaveBeenCalled();
+      expect(mockWhatsAppService.sendMediaMessage).toHaveBeenCalled();
     });
 
     it('should handle service errors', async () => {
@@ -593,8 +592,7 @@ describe('API Router', () => {
         .post('/api/send/media')
         .send({
           number: '1234567890',
-          mediaType: 'url',
-          mediaLocation: 'https://example.com/image.jpg'
+          source: 'https://example.com/image.jpg'
         });
 
       expect(response.status).toBe(500);
@@ -609,8 +607,7 @@ describe('API Router', () => {
         .post('/api/send/media')
         .send({
           number: '1234567890',
-          mediaType: 'url',
-          mediaLocation: 'https://example.com/image.jpg'
+          source: 'https://example.com/image.jpg'
         });
 
       expect(response.status).toBe(503);

--- a/test/unit/mcp-server.test.ts
+++ b/test/unit/mcp-server.test.ts
@@ -115,7 +115,7 @@ describe('MCP Server', () => {
   it('should use WhatsApp API client when useApiClient is true', () => {
     const config: McpConfig = {
       useApiClient: true,
-      apiBaseUrl: 'http://localhost:7001',
+      apiBaseUrl: 'http://localhost:3001',
     };
 
     createMcpServer(config);

--- a/test/unit/mcp-server.test.ts
+++ b/test/unit/mcp-server.test.ts
@@ -115,7 +115,7 @@ describe('MCP Server', () => {
   it('should use WhatsApp API client when useApiClient is true', () => {
     const config: McpConfig = {
       useApiClient: true,
-      apiBaseUrl: 'http://localhost:3001',
+      apiBaseUrl: 'http://localhost:7001',
     };
 
     createMcpServer(config);
@@ -140,26 +140,26 @@ describe('MCP Server', () => {
   it('should register the download_media_from_message tool', () => {
     // Create a mock server with tool method
     const mockToolMethod = jest.fn();
-    const mockServer = { 
+    const mockServer = {
       resource: jest.fn(),
-      tool: mockToolMethod 
+      tool: mockToolMethod
     };
-    
+
     // Override the McpServer mock for this test
     (require('@modelcontextprotocol/sdk/server/mcp.js').McpServer as jest.Mock)
       .mockImplementationOnce(() => mockServer);
-      
+
     // Create a mock client
     const mockClient = { initialize: jest.fn() };
-    
+
     // Call createMcpServer
     const realCreateMcpServer = jest.requireActual('../../src/mcp-server').createMcpServer;
     realCreateMcpServer({}, mockClient);
-    
+
     // Verify the tool was registered
     const calls = mockToolMethod.mock.calls;
     const downloadMediaToolCall = calls.find(call => call[0] === 'download_media_from_message');
-    
+
     expect(downloadMediaToolCall).toBeDefined();
     expect(downloadMediaToolCall[1]).toHaveProperty('messageId');
   });

--- a/test/unit/whatsapp-service.test.ts
+++ b/test/unit/whatsapp-service.test.ts
@@ -653,7 +653,7 @@ describe('WhatsApp Service', () => {
 
   describe('sendMediaMessage', () => {
     const validImageUrl = 'https://example.com/image.jpg';
-    const validLocalPath = '/path/to/image.jpg';
+    const validLocalPath = 'file:///path/to/image.jpg';
     const validNumber = '1234567890';
     const mockMessageId = 'mock-message-id';
 
@@ -667,8 +667,7 @@ describe('WhatsApp Service', () => {
       it('should send image from valid URL successfully', async () => {
         const result = await service.sendMediaMessage({
           number: validNumber,
-          mediaType: 'url',
-          mediaLocation: validImageUrl,
+          source: validImageUrl,
           caption: 'Test caption',
         });
 
@@ -688,10 +687,9 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'url',
-            mediaLocation: 'invalid-url',
+            source: 'invalid-url',
           })
-        ).rejects.toThrow('Failed to send media message');
+        ).rejects.toThrow('Invalid source format');
       });
 
       it('should handle unsupported image formats', async () => {
@@ -700,8 +698,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'url',
-            mediaLocation: 'https://example.com/file.txt',
+            source: 'https://example.com/file.txt',
           })
         ).rejects.toThrow('Failed to send media message');
       });
@@ -711,8 +708,7 @@ describe('WhatsApp Service', () => {
       it('should send image from valid local path successfully', async () => {
         const result = await service.sendMediaMessage({
           number: validNumber,
-          mediaType: 'local',
-          mediaLocation: validLocalPath,
+          source: validLocalPath,
           caption: 'Test caption',
         });
 
@@ -732,8 +728,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'local',
-            mediaLocation: '/invalid/path/image.jpg',
+            source: 'file:///invalid/path/image.jpg',
           })
         ).rejects.toThrow('Failed to send media message');
       });
@@ -744,8 +739,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'local',
-            mediaLocation: '/path/to/file.txt',
+            source: 'file:///path/to/file.txt',
           })
         ).rejects.toThrow('Failed to send media message');
       });
@@ -756,8 +750,7 @@ describe('WhatsApp Service', () => {
         const caption = 'Test caption';
         const result = await service.sendMediaMessage({
           number: validNumber,
-          mediaType: 'url',
-          mediaLocation: validImageUrl,
+          source: validImageUrl,
           caption,
         });
 
@@ -772,8 +765,7 @@ describe('WhatsApp Service', () => {
       it('should send message without caption', async () => {
         const result = await service.sendMediaMessage({
           number: validNumber,
-          mediaType: 'url',
-          mediaLocation: validImageUrl,
+          source: validImageUrl,
         });
 
         expect(result.messageId).toBe(mockMessageId);
@@ -792,8 +784,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'url',
-            mediaLocation: validImageUrl,
+            source: validImageUrl,
           })
         ).rejects.toThrow('Failed to send media message');
       });
@@ -804,8 +795,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'url',
-            mediaLocation: 'https://example.com/file.xyz',
+            source: 'https://example.com/file.xyz',
           })
         ).rejects.toThrow('Failed to send media message');
       });
@@ -816,8 +806,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'local',
-            mediaLocation: '/protected/path/image.jpg',
+            source: 'file:///protected/path/image.jpg',
           })
         ).rejects.toThrow('Failed to send media message');
       });
@@ -828,8 +817,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: validNumber,
-            mediaType: 'url',
-            mediaLocation: validImageUrl,
+            source: validImageUrl,
           })
         ).rejects.toThrow('WhatsApp client not ready');
       });
@@ -838,8 +826,7 @@ describe('WhatsApp Service', () => {
         await expect(
           service.sendMediaMessage({
             number: '',
-            mediaType: 'url',
-            mediaLocation: validImageUrl,
+            source: validImageUrl,
           })
         ).rejects.toThrow('Invalid phone number');
       });


### PR DESCRIPTION
This change extends the existing functionality by adding the ability to send media messages (images only for now)

Changes:
- updates to Dockerfile to copy over `tsconfig.json` and package.json` files before running `npm install`
- linting changes to remove extra white spaces
- add `/send_media` endpoint to api
- add `sendMediaMessage` method to whatsapp api client and service
- register the server tool
- added tests (mocked whatsapp web client in `whatsapp-service.test.ts` to test newly added method)
- updated readme